### PR TITLE
Tentative to fix conflict

### DIFF
--- a/1.6/Common/Source/IntegratedGenes/Stats/StatPart_CertaintyGenetic.cs
+++ b/1.6/Common/Source/IntegratedGenes/Stats/StatPart_CertaintyGenetic.cs
@@ -26,7 +26,7 @@ namespace IntegratedGenes
         {
             if (!req.HasThing) return;
             Pawn p = req.Thing as Pawn;
-            if (!ActiveForPawn(p)) return;
+            if (p == null || !ActiveForPawn(p)) return;
             val *= IsPawnInMainIdeo(p) ? factorPrimary : factorSecondary;
         }
 


### PR DESCRIPTION
There's a compatibility issue with "Star Wars - Fully Functional Lightsabers (Continued)" (https://steamcommunity.com/sharedfiles/filedetails/?id=3539404137&searchtext=star+wars+lightsaber)

HugsLib logs: https://gist.github.com/HugsLibRecordKeeper/b5032aa51b132201fa03e2010bc853ed

Issues: When having a lightsaber (with a crystal) equipped and clicking on "i" icon (to get info on the pawn). The base info tab is empty and an error log appear.

Error log:
Exception filling window for Verse.Dialog_InfoCard: System.NullReferenceException: Object reference not set to an instance of an object [Ref 889F354A]
at IntegratedGenes.StatPart_CertaintyGenetic.ActiveForPawn (Verse.Pawn p) [0x00000] in <6aca84391ba54e6e934bdd3cbf3a7c39>:0 at IntegratedGenes.StatPart_CertaintyGenetic.TransformValue (RimWorld.StatRequest req, System.Single& val) [0x00017] in <6aca84391ba54e6e934bdd3cbf3a7c39>:0

-- 

Example of such fix:
- https://github.com/juanosarg/AlphaBooks/blob/e037ce7c0c624fc7df7bae1fa5b71690b55376d0/1.6/Source/AlphaBooks/StatParts/Multiplier_ByBiome.cs#L15
-  https://github.com/OrionFive/Hospitality/blob/6b6769769e8ed556d18f4a67606e1a1eb5d4fb30/Source/Source/StatWorker_RelationshipDamage.cs#L12